### PR TITLE
[systemd] Make proper D-Bus activation by systemd. Fixes JB#31723

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,11 @@ clean:
 install : src/$(EXE)
 	mkdir -p $(DESTDIR)/usr/libexec
 	mkdir -p $(DESTDIR)/etc/dbus-1/system.d
+	mkdir -p $(DESTDIR)/lib/systemd/system
 	mkdir -p $(DESTDIR)/usr/share/dbus-1/system-services
 	mkdir -p $(DESTDIR)/etc/ofono/push_forwarder.d
 	cp src/$(EXE) $(DESTDIR)/usr/libexec/
 	cp src/provisioning.conf $(DESTDIR)/etc/dbus-1/system.d/
 	cp src/org.nemomobile.provisioning.service $(DESTDIR)/usr/share/dbus-1/system-services/
 	cp ofono-provisioning.conf $(DESTDIR)/etc/ofono/push_forwarder.d/
-
+	cp src/dbus-org.nemomobile.provisioning.service $(DESTDIR)/lib/systemd/system/

--- a/rpm/provisioning-service-filewrite.spec
+++ b/rpm/provisioning-service-filewrite.spec
@@ -33,6 +33,7 @@ mkdir -p %{buildroot}/%{_sharedstatedir}/provisioning_service/
 %files
 %defattr(-,root,root,-)
 %{_libexecdir}/provisioning-service
+/lib/systemd/system/*.service
 %config %{_sysconfdir}/dbus-1/system.d/provisioning.conf
 %{_datadir}/dbus-1/system-services/org.nemomobile.provisioning.service
 %config %{_sysconfdir}/ofono/push_forwarder.d/ofono-provisioning.conf

--- a/rpm/provisioning-service.spec
+++ b/rpm/provisioning-service.spec
@@ -31,6 +31,7 @@ rm -rf %{buildroot}
 %files
 %defattr(-,root,root,-)
 %{_libexecdir}/provisioning-service
+/lib/systemd/system/*.service
 %{_sysconfdir}/dbus-1/system.d/provisioning.conf
 %{_datadir}/dbus-1/system-services/org.nemomobile.provisioning.service
 %{_sysconfdir}/ofono/push_forwarder.d/ofono-provisioning.conf

--- a/src/dbus-org.nemomobile.provisioning.service
+++ b/src/dbus-org.nemomobile.provisioning.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Provisioning service
+
+[Service]
+Type=dbus
+BusName=org.nemomobile.provisioning
+ExecStart=/usr/libexec/provisioning-service

--- a/src/org.nemomobile.provisioning.service
+++ b/src/org.nemomobile.provisioning.service
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=org.nemomobile.provisioning
-Exec=/usr/libexec/provisioning-service
-User=root
+Exec=/bin/false
+SystemdService=dbus-org.nemomobile.provisioning.service


### PR DESCRIPTION
Make proper bus-activation for org.nemomobile.provisioning service.
Add matching systemd unit-file to prevent service start on shutdown.

Signed-off-by: Igor Zhbanov <igor.zhbanov@jolla.com>